### PR TITLE
fix: menu and logo display

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -3,7 +3,6 @@ import { useLocation } from "react-router-dom";
 import Header from "./Header";
 import Sidebar from "./Sidebar";
 import styles from "./Dashboard.module.css";
-import DatePicker from "./DatePicker";
 import useSideBarStore from "../store/sidebarStore";
 
 export default function Dashboard() {

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -16,13 +16,18 @@ import useSideBarStore from "../store/sidebarStore";
 
 function Sidebar() {
   const logout = useAuthStore((state) => state.logout);
+  const { toggleSidebar, sidebarIsOpen } = useSideBarStore();
+
   const navigate = useNavigate();
   const location = useLocation();
 
-  const { toggleSidebar, sidebarIsOpen } = useSideBarStore();
-
-  const isActive = (path) =>
-    (location.pathname === path) & sidebarIsOpen ? styles.link_active : "";
+  const isActive = (path) => {
+    if (sidebarIsOpen) {
+      return location.pathname === path ? styles.link_active : "";
+    } else if (!sidebarIsOpen) {
+      return location.pathname === path ? styles.link_active_notext : "";
+    }
+  };
 
   const handleLogout = async (e) => {
     e.preventDefault();
@@ -49,7 +54,13 @@ function Sidebar() {
       }
     >
       <div className={styles.top}>
-        <img src={logo} alt="logo" />
+        <img
+          className={
+            sidebarIsOpen ? `${styles.logo}` : `${styles.logo} ${styles.hidden}`
+          }
+          src={logo}
+          alt="logo"
+        />
         <button className={styles.close_btn} onClick={toggleSidebar}>
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -99,7 +110,7 @@ function Sidebar() {
               Statistics
             </Link>
           </li>
-          <p>{sidebarIsOpen ? "account" : ""}</p>
+          {sidebarIsOpen ? <p>account</p> : ""}
           <li>
             <Link className={styles.link} to="/dashboard">
               <img src={settingsIcon} alt="dashboard-icon" />

--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -8,6 +8,15 @@
   overflow-x: hidden;
 }
 
+.logo {
+  opacity: 1;
+  transition: all 0.4s;
+}
+
+.logo.hidden {
+  opacity: 0;
+}
+
 .top {
   display: flex;
   position: relative;
@@ -67,6 +76,10 @@
 }
 
 .link_active {
+  background-color: #a273bf;
+}
+
+.link_active_notext {
   background-color: #a273bf;
 }
 


### PR DESCRIPTION
## Changes
- changed the display of active links, now they will not disappear when the sidebar is closed
- the logo now appears and disappears smoothly when the sidebar state changes